### PR TITLE
Deselect a previously selected day

### DIFF
--- a/addon/src/main/java/org/vaadin/addons/minicalendar/MiniCalendar.java
+++ b/addon/src/main/java/org/vaadin/addons/minicalendar/MiniCalendar.java
@@ -405,6 +405,13 @@ public class MiniCalendar extends CustomField<LocalDate> implements HasThemeVari
                 return;
             }
 
+            if (selectedComponent == event.getSource()) {
+                selectedComponent.removeClassName(CSS_SELECTED);
+                selectedComponent = null;
+                setModelValue(null, true);
+                return;
+            }
+
             if (selectedComponent != null) {
                 selectedComponent.removeClassName(CSS_SELECTED);
             }


### PR DESCRIPTION
A new feature is introduced in the component that allows to deselect a previously selected day. Before this improvement, if a user clicked again on the same selected day, no change occurred. With this change, it is now possible to deselect the selected day by setting the model value to null.